### PR TITLE
fix: make invalid states unrepresentable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arxiv"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
 	"Samantha Nguyen, <contact@samanthanguyen.me>",
 ]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Or, add this to `Cargo.toml`:
 
 ```shell
 [dependencies]
-arxiv = "0.1"
+arxiv = "0.2"
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Security audit](https://github.com/acmuta-research/arxiv-rs/actions/workflows/security-audit.yml/badge.svg)](https://github.com/acmuta-research/arxiv-rs/actions/workflows/security-audit.yml)
 [![codecov](https://codecov.io/gh/acmuta-research/arxiv-rs/branch/main/graph/badge.svg?token=6ZSIWAQTHU)](https://codecov.io/gh/acmuta-research/arxiv-rs)
 
-A Rust library for parsing `arXiv` identifiers and references.
+A Rust library for parsing `arXiv` categories, identifiers and references.
 
 ## Install
 
@@ -27,19 +27,25 @@ arxiv = "0.1"
 
 ```rust
 use std::str::FromStr;
-use arxiv::{ArxivId, ArxivStamp};
+use arxiv::*;
 
 // Parse an arXiv identifier
 let id = ArxivId::from_str("arXiv:9912.12345v2").unwrap();
-assert_eq!(id.month, 12);
-assert_eq!(id.year, 2099);
-assert_eq!(id.number, "12345");
-assert_eq!(id.version, Some(2));
+assert_eq!(id.month(), 12);
+assert_eq!(id.year(), 2099);
+assert_eq!(id.number(), "12345");
+assert_eq!(id.version(), Some(2));
+
+// Parse an arXiv category
+let category = ArxivCategoryId::from_str("astro-ph.HE").unwrap();
+assert_eq!(category.group(), ArxivGroup::Physics);
+assert_eq!(category.archive(), ArxivArchive::AstroPh);
+assert_eq!(category.subject(), String::from("HE"));
 
 // Parse an arXiv stamp
 let stamp = ArxivStamp::from_str("arXiv:0706.0001v1 [q-bio.CB] 1 Jun 2007").unwrap();
-assert_eq!(stamp.category, "q-bio.CB");
-assert_eq!(stamp.submitted.year(), 2007);
+assert_eq!(stamp.category(), Some(&ArxivCategoryId::try_new(ArxivArchive::QBio, "CB").unwrap()));
+assert_eq!(stamp.submitted().year(), 2007);
 ```
 
 ## License

--- a/src/category.rs
+++ b/src/category.rs
@@ -1,0 +1,300 @@
+use crate::subject_tables::*;
+use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::str::FromStr;
+
+/// An identifier for arXiv categories, which are composed of an archive and category
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArxivCategoryId {
+	group: ArxivGroup,
+	archive: ArxivArchive,
+	subject: String,
+}
+
+impl ArxivCategoryId {
+	pub(crate) const TOKEN_DELIM: char = '.';
+
+	pub(super) const fn new(group: ArxivGroup, archive: ArxivArchive, subject: String) -> Self {
+		Self {
+			group,
+			archive,
+			subject,
+		}
+	}
+
+	/// Checks if the string is a valid group identifier, based on the archive and category.
+	///
+	/// Valid archive identifiers are listed under the official website's page for [category taxonomy][arxiv-cat].
+	///
+	/// [arxiv-cat]: <https://arxiv.org/category_taxonomy>
+	#[rustfmt::skip]
+	pub fn try_new(archive: ArxivArchive, subject: &str) -> Option<Self> {
+		let is_valid = match archive {
+			ArxivArchive::AstroPh => matches!(subject, "CO" | "EP" | "GA" | "HE" | "IM" | "SR"),
+			ArxivArchive::CondMat => matches!(subject,
+					| "dis-nn" | "mes-hall" | "mtrl-sci"
+					| "other" | "quant-gas" | "soft"
+					| "stat-mech" | "str-el" | "supr-con"
+			),
+			ArxivArchive::Cs => COMPSCI_TABLE.binary_search(&subject).is_ok(),
+			ArxivArchive::Econ => matches!(subject, "EM" | "GN" | "TH"),
+			ArxivArchive::Eess => matches!(subject, "AS" | "IV" | "SP" | "SY"),
+			ArxivArchive::GrQc => subject.is_empty(),
+			ArxivArchive::HepEx => subject.is_empty(),
+			ArxivArchive::HepLat => subject.is_empty(),
+			ArxivArchive::HepPh => subject.is_empty(),
+			ArxivArchive::HepTh => subject.is_empty(),
+			ArxivArchive::MathPh => subject.is_empty(),
+			ArxivArchive::Math => MATH_TABLE.binary_search(&subject).is_ok(),
+			ArxivArchive::Nlin => matches!(subject, "AO" | "CD" | "CG" | "PS" | "SI"),
+			ArxivArchive::NuclEx => subject.is_empty(),
+			ArxivArchive::NuclTh => subject.is_empty(),
+			ArxivArchive::Physics => PHYSICS_TABLE.binary_search(&subject).is_ok(),
+			ArxivArchive::QBio    => matches!(subject, "BM" | "CB" | "GN" | "MN" | "NC" | "OT" | "PE" | "QM" | "SC" | "TO"),
+			ArxivArchive::QFin => {
+				matches!(subject, "CP" | "EC" | "GN" | "MF" | "PM" | "PR" | "RM" | "ST" | "SR")
+			}
+			ArxivArchive::QuantPh => subject.is_empty(),
+			ArxivArchive::Stat => matches!(subject, "AP" | "CO" | "ME" | "ML" | "OT" | "TH"),
+		};
+
+		match is_valid {
+			true => Some(Self::new(ArxivGroup::from(archive), archive, String::from(subject))),
+			false => None,
+		}
+	}
+
+	/// The group, which contains one or more archives
+	#[must_use]
+	#[inline]
+	pub const fn group(&self) -> ArxivGroup {
+		self.group
+	}
+
+	/// The archive, representing a collection of publications
+	/// that relate to each other by a specific field of study
+	#[must_use]
+	#[inline]
+	pub const fn archive(&self) -> ArxivArchive {
+		self.archive
+	}
+
+	/// The subject class of the arXiv category
+	#[must_use]
+	#[inline]
+	pub fn subject(&self) -> String {
+		self.subject.to_owned()
+	}
+}
+
+impl Display for ArxivCategoryId {
+	fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+		write!(f, "{}.{}", self.archive, self.subject)
+	}
+}
+
+impl FromStr for ArxivCategoryId {
+	type Err = ();
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		let parts: Vec<&str> = s.split(Self::TOKEN_DELIM).collect();
+		if parts.len() != 2 {
+			return Err(());
+		}
+
+		let archive = ArxivArchive::from_str(parts[0])?;
+		let subject = parts[1];
+
+		Self::try_new(archive, subject).ok_or(())
+	}
+}
+
+/// A type of classification for arXiv publications
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArxivGroup {
+	/// Computer Science
+	Cs,
+	/// Economics
+	Econ,
+	/// Electrical Engineering and Systems Science
+	Eess,
+	/// Mathematics
+	Math,
+	/// Physics
+	Physics,
+	/// Quantitative Biology
+	QBio,
+	/// Quantitative Finance
+	QFin,
+	/// Statistics
+	Stat,
+}
+
+impl From<ArxivArchive> for ArxivGroup {
+	fn from(archive: ArxivArchive) -> Self {
+		match archive {
+			ArxivArchive::Cs => Self::Cs,
+			ArxivArchive::Econ => Self::Econ,
+			ArxivArchive::Eess => Self::Eess,
+			ArxivArchive::Math => Self::Math,
+			ArxivArchive::AstroPh
+			| ArxivArchive::CondMat
+			| ArxivArchive::GrQc
+			| ArxivArchive::HepEx
+			| ArxivArchive::HepLat
+			| ArxivArchive::HepPh
+			| ArxivArchive::HepTh
+			| ArxivArchive::MathPh
+			| ArxivArchive::Nlin
+			| ArxivArchive::NuclEx
+			| ArxivArchive::NuclTh
+			| ArxivArchive::Physics
+			| ArxivArchive::QuantPh => Self::Physics,
+			ArxivArchive::QBio => Self::QBio,
+			ArxivArchive::QFin => Self::QFin,
+			ArxivArchive::Stat => Self::Stat,
+		}
+	}
+}
+
+/// A collection of publications that relate under the same field of study
+///
+/// Valid archive identifiers are listed under the official website's page for [category taxonomy][arxiv-cat].
+///
+/// [arxiv-cat]: <https://arxiv.org/category_taxonomy>
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArxivArchive {
+	/// Astro physics
+	AstroPh,
+	/// Condensed matter
+	CondMat,
+	/// Computer science
+	Cs,
+	/// Economics
+	Econ,
+	/// Electrical Engineering and Systems Science
+	Eess,
+	/// General Relativity and Quantum Cosmology
+	GrQc,
+	/// High energy physics - Experiment
+	HepEx,
+	/// High energy physics - Lattice
+	HepLat,
+	/// High energy physics - Phenomenology
+	HepPh,
+	/// High energy physics - Theory
+	HepTh,
+	/// Mathematical Physics
+	MathPh,
+	/// Mathematics
+	Math,
+	/// Nonlinear Sciences
+	Nlin,
+	/// Nuclear Experiment
+	NuclEx,
+	/// Nuclear Theory
+	NuclTh,
+	/// Physics
+	Physics,
+	/// Quantitative Biology
+	QBio,
+	/// Quantitative Finance
+	QFin,
+	/// Quantum Physics
+	QuantPh,
+	/// Statistics
+	Stat,
+}
+
+impl Display for ArxivArchive {
+	fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+		write!(
+			f,
+			"{}",
+			match self {
+				ArxivArchive::AstroPh => "astro-ph",
+				ArxivArchive::CondMat => "cond-mat",
+				ArxivArchive::Cs => "cs",
+				ArxivArchive::Econ => "econ",
+				ArxivArchive::Eess => "eess",
+				ArxivArchive::GrQc => "gr-qc",
+				ArxivArchive::HepEx => "hep-ex",
+				ArxivArchive::HepLat => "hep-lat",
+				ArxivArchive::HepPh => "hep-ph",
+				ArxivArchive::HepTh => "hep-th",
+				ArxivArchive::MathPh => "math-ph",
+				ArxivArchive::Math => "math",
+				ArxivArchive::Nlin => "nlin",
+				ArxivArchive::NuclEx => "nucl-ex",
+				ArxivArchive::NuclTh => "nucl-th",
+				ArxivArchive::Physics => "physics",
+				ArxivArchive::QBio => "q-bio",
+				ArxivArchive::QFin => "q-fin",
+				ArxivArchive::QuantPh => "quant-ph",
+				ArxivArchive::Stat => "stat",
+			}
+		)
+	}
+}
+
+impl FromStr for ArxivArchive {
+	type Err = ();
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		match s {
+			"astro-ph" => Ok(Self::AstroPh),
+			"cond-mat" => Ok(Self::CondMat),
+			"cs" => Ok(Self::Cs),
+			"econ" => Ok(Self::Econ),
+			"eess" => Ok(Self::Eess),
+			"gr-qc" => Ok(Self::GrQc),
+			"hep-ex" => Ok(Self::HepEx),
+			"hep-lat" => Ok(Self::HepLat),
+			"hep-ph" => Ok(Self::HepPh),
+			"hep-th" => Ok(Self::HepTh),
+			"math-ph" => Ok(Self::MathPh),
+			"math" => Ok(Self::Math),
+			"nlin" => Ok(Self::Nlin),
+			"nucl-ex" => Ok(Self::NuclEx),
+			"nucl-th" => Ok(Self::NuclTh),
+			"physics" => Ok(Self::Physics),
+			"q-bio" => Ok(Self::QBio),
+			"q-fin" => Ok(Self::QFin),
+			"quant-ph" => Ok(Self::QuantPh),
+			"stat" => Ok(Self::Stat),
+			_ => Err(()),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn parse_category_id() {
+		let cat_id = ArxivCategoryId::from_str("cs.LG");
+		assert_eq!(
+			cat_id,
+			Ok(ArxivCategoryId::new(ArxivGroup::Cs, ArxivArchive::Cs, String::from("LG")))
+		);
+	}
+
+	#[test]
+	fn display_category() {
+		assert_eq!(
+			ArxivCategoryId::try_new(ArxivArchive::AstroPh, "HE")
+				.unwrap()
+				.to_string(),
+			"astro-ph.HE"
+		);
+	}
+
+	#[test]
+	fn group_from_archive() {
+		assert_eq!(ArxivGroup::from(ArxivArchive::AstroPh), ArxivGroup::Physics);
+	}
+
+	#[test]
+	fn parse_archive() {
+		let archive = ArxivArchive::from_str("astro-ph");
+		assert_eq!(archive, Ok(ArxivArchive::AstroPh));
+	}
+}

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -46,10 +46,10 @@ impl Display for ArxivIdError {
 /// [arxiv-docs]: https://info.arxiv.org/help/arxiv_identifier.html
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ArxivId {
-	pub year: u16,
-	pub month: u8,
-	pub number: String,
-	pub version: Option<u8>,
+	year: u16,
+	month: u8,
+	number: String,
+	version: Option<u8>,
 }
 
 impl ArxivId {
@@ -66,14 +66,26 @@ impl ArxivId {
 	/// This allows manually creating an [`ArxivId`] from the given components without any
 	/// validation. Only do this if you have already verified that the components are valid.
 	///
+	/// # Safety
+	///  - The year is between the inclusive range of [2007, 2009].
+	///  - The month is between the inclusive range of [1, 12].
+	///  - The unique number string only contains 4 to 5 ASCII digits.
+	///
 	/// # Examples
 	/// ```
 	/// use arxiv::ArxivId;
 	///
-	/// let id = ArxivId::new_raw(2011, 1, String::from("00001"), Some(1));
+	/// unsafe {
+	///    let id = ArxivId::new_unchecked(2011, 1, String::from("00001"), Some(1));
+	/// }
 	/// ```
 	#[inline]
-	pub const fn new_raw(year: u16, month: u8, number: String, version: Option<u8>) -> Self {
+	pub const unsafe fn new_unchecked(
+		year: u16,
+		month: u8,
+		number: String,
+		version: Option<u8>,
+	) -> Self {
 		Self {
 			year,
 			month,
@@ -86,15 +98,22 @@ impl ArxivId {
 	/// (assuming it is the latest version). Only do this if you have already verified that the
 	/// components are valid.
 	///
+	/// # Safety
+	///  - The year is between the inclusive range of [2007, 2009].
+	///  - The month is between the inclusive range of [1, 12].
+	///  - The unique number string only contains 4 to 5 ASCII digits.
+	///
 	/// # Examples
 	/// ```
 	/// use arxiv::ArxivId;
 	///
-	/// let id = ArxivId::new_latest(2011, 1, String::from("00001"));
+	/// unsafe {
+	///     let id = ArxivId::new_unchecked_latest(2011, 1, String::from("00001"));
+	/// }
 	/// ```
 	#[inline]
-	pub const fn new_latest(year: u16, month: u8, id: String) -> Self {
-		Self::new_raw(year, month, id, None)
+	pub const unsafe fn new_unchecked_latest(year: u16, month: u8, id: String) -> Self {
+		unsafe { Self::new_unchecked(year, month, id, None) }
 	}
 
 	/// This allows manually creating an [`ArxivId`] from the given components with a version, and
@@ -120,7 +139,7 @@ impl ArxivId {
 			return Err(ArxivIdError::InvalidId);
 		}
 
-		Ok(Self::new_raw(year, month, number, version))
+		Ok(unsafe { Self::new_unchecked(year, month, number, version) })
 	}
 
 	/// This allows manually creating an [`ArxivId`] from the given components without a version
@@ -142,6 +161,70 @@ impl ArxivId {
 	#[inline]
 	pub const fn is_latest(&self) -> bool {
 		self.version.is_none()
+	}
+
+	/// The year the arXiv publication was published in
+	///
+	/// # Examples
+	/// ```
+	/// use arxiv::ArxivId;
+	/// use std::str::FromStr;
+	///
+	/// let id = ArxivId::from_str("arXiv:2304.11188v1").unwrap();
+	/// assert_eq!(id.year(), 2023);
+	/// ```
+	#[must_use]
+	#[inline]
+	pub const fn year(&self) -> u16 {
+		self.year
+	}
+
+	/// The month the arXiv publication was published in
+	///
+	/// # Examples
+	/// ```
+	/// use arxiv::ArxivId;
+	/// use std::str::FromStr;
+	///
+	/// let id = ArxivId::from_str("arXiv:2304.11188v1").unwrap();
+	/// assert_eq!(id.month(), 04);
+	/// ```
+	#[must_use]
+	#[inline]
+	pub const fn month(&self) -> u8 {
+		self.month
+	}
+
+	/// The uniquely assigned identifier of the arXiv publication
+	///
+	/// # Examples
+	/// ```
+	/// use arxiv::ArxivId;
+	/// use std::str::FromStr;
+	///
+	/// let id = ArxivId::from_str("arXiv:2304.11188v1").unwrap();
+	/// assert_eq!(id.number(), String::from("11188"));
+	/// ```
+	#[must_use]
+	#[inline]
+	pub fn number(&self) -> String {
+		self.number.to_owned()
+	}
+
+	/// The latest version of the arXiv publication, if any.
+	///
+	/// # Examples
+	/// ```
+	/// use arxiv::ArxivId;
+	/// use std::str::FromStr;
+	///
+	///  let id = ArxivId::from_str("arXiv:2304.11188v1").unwrap();
+	/// assert_eq!(id.version(), Some(1u8));
+	/// ```
+	#[must_use]
+	#[inline]
+	pub const fn version(&self) -> Option<u8> {
+		self.version
 	}
 
 	/// Sets the version of the arXiv article.
@@ -251,7 +334,7 @@ mod tests {
 	fn parse_arxiv_without_version() {
 		assert_eq!(
 			ArxivId::from_str("arXiv:1501.00001"),
-			Ok(ArxivId::new_latest(2015, 1, String::from("00001")))
+			Ok(unsafe { ArxivId::new_unchecked_latest(2015, 1, String::from("00001")) })
 		);
 	}
 
@@ -259,18 +342,18 @@ mod tests {
 	fn parse_arxiv_with_version() {
 		assert_eq!(
 			ArxivId::from_str("arXiv:9912.12345v2"),
-			Ok(ArxivId::new_raw(2099, 12, String::from("12345"), Some(2)))
+			Ok(unsafe { ArxivId::new_unchecked(2099, 12, String::from("12345"), Some(2)) })
 		)
 	}
 
 	#[test]
 	fn arxiv_as_string_number4digits() {
 		assert_eq!(
-			ArxivId::new_latest(2014, 1, String::from("7878")).to_string(),
+			unsafe { ArxivId::new_unchecked_latest(2014, 1, String::from("7878")).to_string() },
 			String::from("arXiv:1401.7878")
 		);
 		assert_eq!(
-			ArxivId::new_latest(2014, 12, String::from("7878")).to_string(),
+			unsafe { ArxivId::new_unchecked_latest(2014, 12, String::from("7878")).to_string() },
 			String::from("arXiv:1412.7878")
 		);
 	}
@@ -278,11 +361,11 @@ mod tests {
 	#[test]
 	fn arxiv_as_string_number5digits() {
 		assert_eq!(
-			ArxivId::new_latest(2014, 1, String::from("00008")).to_string(),
+			unsafe { ArxivId::new_unchecked_latest(2014, 1, String::from("00008")).to_string() },
 			String::from("arXiv:1401.00008")
 		);
 		assert_eq!(
-			ArxivId::new_latest(2014, 12, String::from("00008")).to_string(),
+			unsafe { ArxivId::new_unchecked_latest(2014, 12, String::from("00008")).to_string() },
 			String::from("arXiv:1412.00008")
 		);
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,10 @@
 #![doc = include_str!("../README.md")]
 
+mod category;
 mod identifier;
 mod stamp;
+mod subject_tables;
+pub use crate::category::*;
 pub use crate::identifier::*;
 pub use crate::stamp::*;
 

--- a/src/stamp.rs
+++ b/src/stamp.rs
@@ -102,7 +102,7 @@ impl Display for ArxivStamp {
 	fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
 		// A stamp string is *at least* 25 characters long:
 		// - 16: longest possible arXiv identifier
-		// - 2: string length of a zero-padded day
+		// - 2: string length of a day
 		// - 3: string length of an abbreviated month
 		// - 4: string length of a 4-digit year
 		let mut partial_stamp_str = String::with_capacity(16usize);

--- a/src/stamp.rs
+++ b/src/stamp.rs
@@ -1,4 +1,4 @@
-use crate::{ArxivId, ArxivIdError};
+use crate::{ArxivCategoryId, ArxivId, ArxivIdError};
 use std::error::Error;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::str::FromStr;
@@ -8,7 +8,6 @@ use time::{Date, Month};
 
 /// Convenient type alias for a [`Result`] holding either an [`ArxivStamp`] or [`ArxivStampError`]
 pub type ArxivStampResult = Result<ArxivStamp, ArxivStampError>;
-type CategoryResult = Result<String, ArxivStampError>;
 type DateParseResult = Result<Date, TimeParseError>;
 
 /// An error that can occur when parsing and validating arXiv stamps
@@ -44,46 +43,86 @@ impl Display for ArxivStampError {
 /// A stamp that is added onto the side of PDF version of arXiv articles
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ArxivStamp {
-	pub id: ArxivId,
-	pub category: String,
-	pub submitted: Date,
+	id: ArxivId,
+	category: Option<ArxivCategoryId>,
+	submitted: Date,
 }
 
 impl ArxivStamp {
 	pub(crate) const TOKEN_SPACE: char = ' ';
 
-	/// Manually create a new [`ArxivStamp`] from the given components. This is useful
-	/// if you want to dynamically create a stamp from user input; otherwise, it is
-	/// recommended to use [`ArxivStamp::from_str()`] instead since it can be quite verbose.
-	///
+	/// Manually create a new [`ArxivStamp`] from the given components.
+
 	/// # Examples
 	/// ```
+	/// use arxiv::{ArxivArchive, ArxivCategoryId, ArxivId, ArxivStamp};
 	/// use time::{Date, Month};
-	/// use arxiv::{ArxivId, ArxivStamp};
 	///
 	/// let stamp = ArxivStamp::new(
 	///    ArxivId::try_latest(2011, 1, String::from("00001")).unwrap(),
-	///    String::from("cs.LG"),
+	///    Some(ArxivCategoryId::try_new(ArxivArchive::Cs, "LG").unwrap()),
 	///    Date::from_calendar_date(2011, Month::January, 1).unwrap()
 	/// );
 	/// ```
 	#[inline]
-	pub const fn new(id: ArxivId, category: String, submitted: Date) -> Self {
+	pub const fn new(id: ArxivId, category: Option<ArxivCategoryId>, submitted: Date) -> Self {
 		Self {
 			id,
 			category,
 			submitted,
 		}
 	}
+
+	/// The unique arXiv identifier of the stamp
+	#[must_use]
+	#[inline]
+	pub const fn id(&self) -> &ArxivId {
+		&self.id
+	}
+
+	/// The category of the stamp
+	#[must_use]
+	#[inline]
+	pub const fn category(&self) -> Option<&ArxivCategoryId> {
+		match &self.category {
+			Some(c) => Some(c),
+			None => None,
+		}
+	}
+
+	/// The submitted date of the given publication for the stamp
+	#[must_use]
+	#[inline]
+	pub const fn submitted(&self) -> Date {
+		self.submitted
+	}
 }
 
 impl Display for ArxivStamp {
 	fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+		// A stamp string is *at least* 25 characters long:
+		// - 16: longest possible arXiv identifier
+		// - 2: string length of a zero-padded day
+		// - 3: string length of an abbreviated month
+		// - 4: string length of a 4-digit year
+		let mut partial_stamp_str = String::with_capacity(16usize);
+		partial_stamp_str.push_str(&self.id.to_string());
+		match &self.category {
+			Some(c) => {
+				// This is the longest possible length of a category string,
+				// such as "cond-mat.quant-gas"
+				partial_stamp_str.reserve(18usize);
+				partial_stamp_str.push_str(" [");
+				partial_stamp_str.push_str(&c.to_string());
+				partial_stamp_str.push(']');
+			}
+			None => (),
+		}
+
 		write!(
 			f,
-			"{} [{}] {} {} {}",
-			self.id,
-			self.category,
+			"{} {} {} {}",
+			partial_stamp_str,
 			self.submitted.day(),
 			month_as_abbr(self.submitted.month()),
 			self.submitted.year()
@@ -109,7 +148,7 @@ impl FromStr for ArxivStamp {
 		// category is opitional, so we need to check if the second part is a category
 		// and decide which index to use to parse each component
 		let part2_is_category = parts[1].starts_with('[');
-		let mut category: CategoryResult = Ok(String::new());
+		let mut category: Option<ArxivCategoryId> = None;
 		let date: DateParseResult;
 
 		if part2_is_category {
@@ -117,17 +156,17 @@ impl FromStr for ArxivStamp {
 				.splitn(2, ArxivStamp::TOKEN_SPACE)
 				.collect::<Vec<&str>>();
 
-			category = parse_category(category_date[0]);
+			let str_in_brackets =
+				parse_brackets(category_date[0]).map_err(|_| ArxivStampError::InvalidCategory)?;
+			let parsed_category = ArxivCategoryId::from_str(&str_in_brackets);
+			if parsed_category.is_err() {
+				return Err(ArxivStampError::InvalidCategory);
+			}
+
+			category = parsed_category.ok();
 			date = parse_date(category_date[1]);
 		} else {
 			date = parse_date(parts[1]);
-		}
-
-		// validate the category and date components
-		// converting this to category? will cause the value to move,
-		#[allow(clippy::question_mark)]
-		if let Err(e) = category {
-			return Err(e);
 		}
 
 		if let Err(e) = date {
@@ -135,22 +174,21 @@ impl FromStr for ArxivStamp {
 		}
 
 		// if we got this far, we can safely unwrap the results
-		Ok(Self::new(arxiv_id.unwrap(), category.unwrap(), date.unwrap()))
+		Ok(Self::new(arxiv_id.unwrap(), category, date.unwrap()))
 	}
 }
 
-fn parse_category(s: &str) -> CategoryResult {
-	if brackets_match(s) {
-		Ok(s[1..s.len() - 1].to_string())
-	} else {
-		Err(ArxivStampError::InvalidCategory)
+pub(super) fn parse_brackets(s: &str) -> Result<String, ()> {
+	match brackets_match(s) {
+		true => Ok(s[1..s.len() - 1].to_string()),
+		false => Err(()),
 	}
 }
 
-fn brackets_match(s: &str) -> bool {
+/// We only care *and* allow for straight brackets,
+/// we don't care for parentheses or curly brackets
+pub(super) fn brackets_match(s: &str) -> bool {
 	s.starts_with('[') && s.ends_with(']')
-		|| s.starts_with('(') && s.ends_with(')')
-		|| s.starts_with('{') && s.ends_with('}')
 }
 
 const fn month_as_abbr<'a>(month: Month) -> &'a str {
@@ -185,6 +223,7 @@ fn parse_date(date_str: &str) -> DateParseResult {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::ArxivArchive;
 	use std::str::FromStr;
 	use time::error::ParseFromDescription;
 	use time::Date;
@@ -193,10 +232,21 @@ mod tests {
 	fn display_stamp() {
 		let stamp = ArxivStamp::new(
 			ArxivId::from_str("arXiv:2011.00001").unwrap(),
-			String::from("cs.LG"),
+			Some(ArxivCategoryId::try_new(crate::ArxivArchive::Cs, "LG").unwrap()),
 			Date::from_calendar_date(2011, Month::January, 1).unwrap(),
 		);
 		assert_eq!(stamp.to_string(), "arXiv:2011.00001 [cs.LG] 1 Jan 2011");
+	}
+
+	#[test]
+	fn display_stamp_without_category() {
+		let stamp = ArxivStamp::new(
+			ArxivId::from_str("arXiv:2011.00001").unwrap(),
+			None,
+			Date::from_calendar_date(2011, Month::January, 1).unwrap(),
+		);
+
+		assert_eq!(stamp.to_string(), "arXiv:2011.00001 1 Jan 2011");
 	}
 
 	#[test]
@@ -207,8 +257,8 @@ mod tests {
 			parsed,
 			Ok(ArxivStamp::new(
 				ArxivId::from_str("arXiv:2001.00001").unwrap(),
-				String::from("cs.LG"),
-				Date::from_calendar_date(2000, Month::January, 1).unwrap()
+				Some(ArxivCategoryId::try_new(ArxivArchive::Cs, "LG").unwrap()),
+				Date::from_calendar_date(2000, Month::January, 1).unwrap(),
 			))
 		);
 	}
@@ -221,8 +271,8 @@ mod tests {
 			parsed,
 			Ok(ArxivStamp::new(
 				ArxivId::from_str("arXiv:2001.00001").unwrap(),
-				String::new(),
-				Date::from_calendar_date(2000, Month::January, 1).unwrap()
+				None,
+				Date::from_calendar_date(2000, Month::January, 1).unwrap(),
 			))
 		);
 	}
@@ -277,5 +327,20 @@ mod tests {
 		ArxivStampError::InvalidDate(TimeParseError::ParseFromDescription(
 			ParseFromDescription::InvalidComponent(component),
 		))
+	}
+
+	#[test]
+	fn test_parse_brackets() {
+		assert_eq!(Err(()), parse_brackets(""));
+		assert_eq!(Ok(String::new()), parse_brackets("[]"));
+		assert_eq!(Ok(String::from("test")), parse_brackets("[test]"));
+	}
+
+	#[test]
+	fn test_brackets_match() {
+		assert_eq!(false, brackets_match(""));
+		assert_eq!(true, brackets_match("[]"));
+		assert_eq!(false, brackets_match("{}"));
+		assert_eq!(false, brackets_match("()"));
 	}
 }

--- a/src/subject_tables.rs
+++ b/src/subject_tables.rs
@@ -1,0 +1,18 @@
+// TODO: Auto-generate the tables below from "https://arxiv.org/category_taxonomy" in a build.rs file
+
+pub(crate) const COMPSCI_TABLE: &[&str] = &[
+	"AI", "AR", "CC", "CE", "CG", "CL", "CR", "CV", "CY", "DB", "DC", "DL", "DM", "DS", "ET", "FL",
+	"GL", "GR", "GT", "HC", "IR", "IT", "LG", "LO", "MA", "MM", "MS", "NA", "NI", "OH", "OS", "PF",
+	"PL", "RO", "SC", "SD", "SE", "SI", "SY",
+];
+
+pub(crate) const MATH_TABLE: &[&str] = &[
+	"AC", "AG", "AP", "AT", "CA", "CO", "CT", "CV", "DG", "DS", "FA", "GM", "GN", "GR", "GT", "HO",
+	"IT", "KT", "LO", "MG", "MP", "NA", "NT", "OA", "OC", "PR", "QA", "RA", "RT", "SG", "SP", "ST",
+];
+
+pub(crate) const PHYSICS_TABLE: &[&str] = &[
+	"acc-ph", "ao-ph", "app-ph", "atm-clus", "atom-ph", "bio-ph", "chem-ph", "class-ph", "comp-ph",
+	"data-an", "ed-pn", "flu-dyn", "gen-ph", "geo-ph", "hist-ph", "ins-det", "med-ph", "optics",
+	"plasm-ph", "pop-ph", "soc-ph", "space-ph",
+];


### PR DESCRIPTION
 - introduce strongly typed arXiv categories
 - hide fields in structs for ArxivStamp + ArxivId to make it impossible to have invalid states
   - introduce getters
 - fix: correctly display arXiv stamps that don't have a category
 - fix: only parse categories in stamps if they have the right type of brackets like [ or ], disallow parentheses and curly brackets
 - bump crate version